### PR TITLE
Extra backslash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV PYTHONUNBUFFERED=1 \
 COPY requirements.txt /app/requirements.txt
 
 RUN pip install --no-cache-dir --upgrade pip &&  \
-    pip install --no-cache-dir -r requirements.txt \
+    pip install --no-cache-dir -r requirements.txt
 
 COPY app /app
 


### PR DESCRIPTION
The error occurs due to incorrect syntax in the RUN command and incorrect placement of the COPY command.
![Screenshot from 2025-03-28 22-32-25](https://github.com/user-attachments/assets/7bc62f2e-696e-4d08-ad2d-6d4e69e4087b)

![Screenshot from 2025-03-28 22-34-10](https://github.com/user-attachments/assets/0684f1d4-d897-4473-8a25-ac3ad7baf3ff)
![image](https://github.com/user-attachments/assets/3e2a77cb-2365-4fb7-a276-c339e3664961)
1. The COPY command was incorrectly placed inside the RUN command.
2. There was an extra backslash (\) at the end of the line.

The Dockerfile should now work correctly.
![Screenshot from 2025-03-28 22-38-11](https://github.com/user-attachments/assets/477ae7ec-131e-4bf7-83b5-360fd357c2ec)
